### PR TITLE
Execute .EXE and .COM

### DIFF
--- a/blink16/blink16.c
+++ b/blink16/blink16.c
@@ -274,7 +274,8 @@ void LoadProgram(struct Machine *m, char *prog, char **args, char **vars)
             m->system->codestart = Tsegment << 4;
             m->system->codesize = exe8086.aout.tseg;
         }
-    } else if (endswith(prog, ".exe") || endswith(prog, ".com")) {
+    } else if (endswith(prog, ".exe") || endswith(prog, ".EXE") || \
+        endswith(prog, ".com") || endswith(prog, ".COM")) {
         loadExecutableDOS(&exe8086, prog, ac, args, vars);
     } else {
         loadExecutableElks(&exe8086, prog, ac, args, vars);


### PR DESCRIPTION
Blink didn't recognise capitalised file extensions which are common for DOS programs. It is fixed now.